### PR TITLE
fix(hasura-gql-docker-image): update version as 2.13.0 has been removed

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,7 +103,7 @@ services:
       PGADMIN_DEFAULT_EMAIL: pgadmin@example.com
       PGADMIN_DEFAULT_PASSWORD: admin
   graphql-engine:
-    image: hasura/graphql-engine:v2.13.0
+    image: hasura/graphql-engine:v2.13.2
     ports:
       - "8081:8080"
     depends_on:


### PR DESCRIPTION
Fixing this error caused by deprecated/deleted image version from [hasura/graphql-engine docker image update](https://hub.docker.com/r/hasura/graphql-engine)

--- 

On 7th Dec 2022 10:00 AM PST, Hasura removed certain images that were impacted by a security vulnerability from this repository to prevent them being run in production. We encourage anyone who is impacted update to a patched version immediately.

More details can be found on this security advisory: https://github.com/hasura/graphql-engine/security/advisories/GHSA-g7mj-g7f4-hgrg

Affected versions | Patched version
-- | --
v2.15.1, v2.15.0 | v2.15.2
v2.14.0 | v2.14.1
v2.13.1, v2.13.0 | v2.13.2
v2.12.0 | v2.12.1
v2.11.2, v2.11.1, v2.11.0 | v2.11.3
v2.10.1, v2.10.0 | v2.10.2

--- 

![image](https://user-images.githubusercontent.com/23119955/208083429-3456d88a-2ca0-45ec-8642-a777bbacfff4.png)

